### PR TITLE
Options bind dynamic

### DIFF
--- a/src/app/ng2-google-place.directive.ts
+++ b/src/app/ng2-google-place.directive.ts
@@ -86,8 +86,19 @@ export class GooglePlaceDirective implements OnInit, OnChanges {
 
   }
   
+
   ngOnChanges(event: any) {
-    this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, event.options.currentValue);
+    if (event.options.previousValue && event.options.currentValue) {
+      if (event.options.currentValue.componentRestrictions.country !== event.options.previousValue.componentRestrictions.country) {
+        this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, event.options.currentValue);
+        this.trigger = this.autocomplete.addListener('place_changed', () => {
+            this.place = this.autocomplete.getPlace();
+            if (this.place && this.place.place_id){
+            this.invokeEvent();
+          }
+        });
+      }
+    }
   }
 
   ngOnInit() {

--- a/src/app/ng2-google-place.directive.ts
+++ b/src/app/ng2-google-place.directive.ts
@@ -85,18 +85,11 @@ export class GooglePlaceDirective implements OnInit, OnChanges {
   constructor(private el: ElementRef, private service: GooglePlaceService, private ngZone: NgZone) {
 
   }
-  
 
   ngOnChanges(event: any) {
     if (event.options.previousValue && event.options.currentValue) {
       if (event.options.currentValue.componentRestrictions.country !== event.options.previousValue.componentRestrictions.country) {
-        this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, event.options.currentValue);
-        this.trigger = this.autocomplete.addListener('place_changed', () => {
-            this.place = this.autocomplete.getPlace();
-            if (this.place && this.place.place_id){
-            this.invokeEvent();
-          }
-        });
+        this.setAutocompleteAndInvokeEvent(event.options.currentValue);
       }
     }
   }
@@ -111,14 +104,16 @@ export class GooglePlaceDirective implements OnInit, OnChanges {
       return;
     }
 
-    this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, this.options);
+    this.setAutocompleteAndInvokeEvent(this.options);
+  }
+
+  setAutocompleteAndInvokeEvent(options: any) {
+    this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, options);
     this.trigger = this.autocomplete.addListener('place_changed', () => {
-      this.ngZone.run(() => {
-        this.place = this.autocomplete.getPlace();
-        if (this.place && this.place.place_id) {
-          this.invokeEvent();
-        }
-      });
+      this.place = this.autocomplete.getPlace();
+      if (this.place && this.place.place_id) {
+        this.invokeEvent();
+      }
     });
   }
 

--- a/src/app/ng2-google-place.directive.ts
+++ b/src/app/ng2-google-place.directive.ts
@@ -110,10 +110,12 @@ export class GooglePlaceDirective implements OnInit, OnChanges {
   setAutocompleteAndInvokeEvent(options: any) {
     this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, options);
     this.trigger = this.autocomplete.addListener('place_changed', () => {
-      this.place = this.autocomplete.getPlace();
-      if (this.place && this.place.place_id) {
-        this.invokeEvent();
-      }
+      this.ngZone.run(() => {
+        this.place = this.autocomplete.getPlace();
+        if (this.place && this.place.place_id) {
+          this.invokeEvent();
+        }
+      });
     });
   }
 

--- a/src/app/ng2-google-place.directive.ts
+++ b/src/app/ng2-google-place.directive.ts
@@ -5,7 +5,8 @@ import {
   NgZone,
   ElementRef,
   EventEmitter,
-  OnInit
+  OnInit,
+  OnChanges
 } from '@angular/core';
 import {GooglePlaceService} from './ng2-google-place.service';
 import {Address} from './ng2-google-place.classes';
@@ -15,7 +16,7 @@ declare let google: any;
   selector: '[ng2-google-place-autocomplete]',
 
 })
-export class GooglePlaceDirective implements OnInit {
+export class GooglePlaceDirective implements OnInit, OnChanges {
   @Input('options') options: any;
 
   @Output() CountryCodes: EventEmitter<any> = new EventEmitter();
@@ -83,6 +84,10 @@ export class GooglePlaceDirective implements OnInit {
 
   constructor(private el: ElementRef, private service: GooglePlaceService, private ngZone: NgZone) {
 
+  }
+  
+  ngOnChanges(event: any) {
+    this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, event.options.currentValue);
   }
 
   ngOnInit() {


### PR DESCRIPTION
## Reason
When the country value is changed, the autocomplete doesn't search with the current value.
Has a issue about this: https://github.com/psykolm22/ng2-google-place-autocomplete/issues/11

## What was done?
* NgOnChanges to set new google.maps.places.Autocomplete of GoogleApi